### PR TITLE
Add missing use statements in winit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ And extend your main.rs:
 ```rust
 extern crate winit;
 
-use winit::{EventsLoop, WindowBuilder, dpi::LogicalSize};
+use winit::{EventsLoop, WindowBuilder, dpi::LogicalSize, Event, WindowEvent};
 
 const WIDTH: u32 = 800;
 const HEIGHT: u32 = 600;


### PR DESCRIPTION
Copied from https://github.com/bwasty/vulkan-tutorial-rs/blob/f2f6935914bec4e79937b8cac415683c9fbadcb1/src/bin/00_base_code.rs